### PR TITLE
add new vueSelectLabel prop to prevent label prop from being used in …

### DIFF
--- a/src/components/Form/TextInput.vue
+++ b/src/components/Form/TextInput.vue
@@ -2,7 +2,8 @@
   <div class="input-container">
     <label class="label" :for="id">
       <span v-if="srOnlyLabel" class="sr-only">{{ srOnlyLabel }}</span>
-      {{ label }}
+      <span v-if="type === 'vue-select'">{{ vueSelectLabel }}</span>
+      <span v-else-if="type === 'textarea'">{{ label }}</span>
     </label>
     <VueSelect
       v-if="type === 'vue-select'"
@@ -40,6 +41,9 @@ export default {
       required: true,
     },
     srOnlyLabel: {
+      type: String,
+    },
+    vueSelectLabel: {
       type: String,
     },
     type: {


### PR DESCRIPTION
…vue select dropdown

I implemented this because vueSelect uses the "label" property to determine what field is displayed in the select dropdown. To allow the dropdown to have a separate "English" label it needs to be separate from the existing "label" prop. (I'm open to better reoslutions to this issue.)